### PR TITLE
Quad2

### DIFF
--- a/quad/typed/measure.rkt
+++ b/quad/typed/measure.rkt
@@ -39,7 +39,7 @@
 
 (: get-cache-file-path (-> Path))
 (define (get-cache-file-path)
-  (build-path "../base/font.cache"))
+  (build-path "./font.cache"))
 
 (: update-text-cache-file (-> Void))
 (define (update-text-cache-file)

--- a/quad/untyped/measure.rkt
+++ b/quad/untyped/measure.rkt
@@ -34,7 +34,7 @@
   (/ (round (* base x)) base))
 
 (define (get-cache-file-path)
-  (build-path "../base/font.cache"))
+  (build-path "./font.cache"))
 
 (define (update-text-cache-file)
   (define ctc (current-text-cache))


### PR DESCRIPTION
Quad, revised, to hopefully stop the errors we saw in `racket/serialize`. The `font.cache` file is now saved to the current directory, instead of `base/`, and we check for `eof` when using the file (and fail silently.)

Hopefully moving the file got rid of all eof problems.
