### PR TITLE
[geometric] computing geom. mean, instead of mean over all measurements

### DIFF
--- a/paper/scripts/summary.rkt
+++ b/paper/scripts/summary.rkt
@@ -191,6 +191,14 @@
 (define (avg-runtime sm)
   (mean (all-gt-runtimes sm)))
 
+;; Geometric mean of all gradual lattice means (mean of means, excluding top & bot)
+(define (geometric-avg sm)
+  (define vec (summary-dataset sm))
+  (define N (vector-length vec))
+  (define invN (/ 1 (- N 2)))
+  (for/product ([i (in-range 1 (sub1 N))])
+    (expt (mean (vector-ref vec i)) invN)))
+
 ;; -----------------------------------------------------------------------------
 ;; --- viewing
 
@@ -219,7 +227,7 @@
                (text->pict (format "(~a modules)" (get-num-modules sm)))
                (text->pict (overhead (typed-mean sm)))
                (text->pict (overhead (max-runtime sm)))
-               (text->pict (overhead (avg-runtime sm)))))
+               (text->pict (overhead (geometric-avg sm)))))
   (vl-append vpad
              (hc-append hspace left-column right-column)
              (blank 1 vpad)))


### PR DESCRIPTION
Geometric mean = "central tendency" based on product.
`geometric-mean(values) = (for/product ([v values]) (expt v (/ 1 (length values))))`

In terms of geometry, this mean is the length of one side of the **cube** with area equal to the N-dimensional cuboid with one side for each `value`.

Compared to the means-over-all-measurements

```
|------------+-------+----------|
| benchmark  |  mean | geo.mean |
|------------+-------+----------|
| sieve      | 68.66 |   101.79 |
| morsecode  |  1.44 |     1.44 |
| mbta       |  1.96 |     1.73 |
| zordoz     |  2.78 |     2.58 |
| suffixtree | 28.74 |    17.17 |
| lnm        |  0.61 |     0.52 |
| kcfa       |  9.16 |     6.15 |
| synth      | 21.10 |    18.11 |
| tetris     | 27.12 |    11.34 |
| snake      | 35.05 |    21.24 |
| gregor     |  2.76 |     2.66 |
|------------+-------+----------|

```
