### PR TITLE
Module Graphs now fit within page margins

### DIFF
--- a/paper/module-graphs/funkytown.tex
+++ b/paper/module-graphs/funkytown.tex
@@ -1,8 +1,8 @@
 \begin{tikzpicture}
 
   \node (00)               {\rkt{3}{array-utils}};
-  \node (01) [below of=00,xshift=0.5cm] {};
-  \node (02) [below of=01,xshift=0.5cm] {\rkt{4}{data}};
+  \node (01) [below of=00,yshift=0.3cm] {};
+  \node (02) [below of=01,yshift=0.3cm] {\rkt{4}{data}};
 
   \node (10) [left of=00] {};
   \node (11) [left of=01] {\rkt{1}{array-struct}};
@@ -26,21 +26,21 @@
   %% array broadcast
   \draw[->] (20) -- (11);
   \draw[->] (20) -- (00);
-  \draw[->] (20) -- (02);
+  \draw[->] (20) edge[bend left=15] (02);
   %% array-struct
   \draw[->] (11) -- (00);
   \draw[->] (11) -- (02);
   %% array-transform
   \draw[->] (30) -- (20);
   \draw[->] (30) -- (11);
-  \draw[->] (30) edge[bend left=15] (00);
+  \draw[->] (30) edge[bend left=35] (00);
   \draw[->] (30) -- (02);
   %% drum
   \draw[->] (42) -- (11);
   \draw[->] (42) -- (30);
   \draw[->] (42) -- (00);
-  \draw[->] (42) edge[bend right=15] (02);
-  \draw[->] (42) edge[bend right=15] (22);
+  \draw[->] (42) edge[bend right=35] (02);
+  \draw[->] (42) edge[bend right=35] (22);
   %% main
   \draw[->] (51) -- (42);
   \draw[->] (51) -- (32);

--- a/paper/module-graphs/gregor.tex
+++ b/paper/module-graphs/gregor.tex
@@ -59,26 +59,26 @@
   \draw[->] (42) -- (01);
   \draw[->] (42) -- (10);
   \draw[->] (42) -- (11);
-  \draw[->] (42) edge[bend right=60] (12);
+  \draw[->] (42) edge[bend right=35] (12);
   \draw[->] (42) -- (22);
   \draw[->] (42) -- (31);
   %% moment-base
-  \draw[->] (40) edge[bend left=60] (10);
+  \draw[->] (40) edge[bend left=35] (10);
   \draw[->] (40) -- (31);
   %% offset-resolvers
   \draw[->] (50) -- (01);
-  \draw[->] (50) edge[bend left=60] (10);
+  \draw[->] (50) edge[bend left=35] (10);
   \draw[->] (50) -- (11);
   \draw[->] (50) -- (31);
   \draw[->] (50) -- (40);
   %% moment
-  \draw[->] (60) edge[bend left=60] (10);
+  \draw[->] (60) edge[bend left=35] (10);
   \draw[->] (60) -- (11);
   \draw[->] (60) -- (31);
-  \draw[->] (60) edge[bend left=60] (40);
+  \draw[->] (60) edge[bend left=35] (40);
   \draw[->] (60) -- (50);
   %% clock
-  \draw[->] (70) edge[bend left=60] (10);
+  \draw[->] (70) edge[bend left=35] (10);
   \draw[->] (70) -- (31);
   \draw[->] (70) -- (60);
   %% main

--- a/paper/module-graphs/kcfa.tex
+++ b/paper/module-graphs/kcfa.tex
@@ -11,20 +11,20 @@
   %% -- edges
   \draw[->] (1) -- (0);
   \draw[->] (2) -- (1);
-  \draw[->] (2) edge[bend right=50] (0);
+  \draw[->] (2) edge[bend right=35] (0);
   \draw[->] (3) -- (2);
-  \draw[->] (3) edge[bend left=50] (0);
-  \draw[->] (3) edge[bend left=50] (1);
+  \draw[->] (3) edge[bend left=35] (0);
+  \draw[->] (3) edge[bend left=35] (1);
   \draw[->] (4) -- (3);
-  \draw[->] (4) edge[bend right=50] (0);
-  \draw[->] (4) edge[bend right=50] (1);
-  \draw[->] (4) edge[bend right=50] (2);
+  \draw[->] (4) edge[bend right=35] (0);
+  \draw[->] (4) edge[bend right=35] (1);
+  \draw[->] (4) edge[bend right=35] (2);
   \draw[->] (5) -- (4);
-  \draw[->] (5) edge[bend left=50] (0);
-  \draw[->] (5) edge[bend left=50] (1);
-  \draw[->] (5) edge[bend left=50] (2);
-  \draw[->] (5) edge[bend left=50] (3);
+  \draw[->] (5) edge[bend left=35] (0);
+  \draw[->] (5) edge[bend left=35] (1);
+  \draw[->] (5) edge[bend left=35] (2);
+  \draw[->] (5) edge[bend left=35] (3);
   \draw[->] (6) -- (5);
-  \draw[->] (6) edge[bend right=50] (0);
+  \draw[->] (6) edge[bend right=35] (0);
 
 \end{tikzpicture}

--- a/paper/module-graphs/quad.tex
+++ b/paper/module-graphs/quad.tex
@@ -1,13 +1,13 @@
 \begin{tikzpicture}
 
   \node (00)               {\rkt{14}{world}};
-  \node (01) [below of=00] {\rkt{9}{quads}};
-  \node (02) [below of=01] {\rkt{12}{sugar}};
-  \node (03) [below of=02] {\rkt{7}{penalty}};
-  \node (04) [below of=03] {\rkt{4}{ocm-struct}};
-  \node (05) [below of=04] {\rkt{3}{measure}};
-  \node (06) [below of=05] {\rkt{0}{exceptions}};
-  \node (07) [below of=06] {\rkt{6}{patterns-hashed}};
+  \node (01) [below of=00,yshift=0.2cm] {\rkt{9}{quads}};
+  \node (02) [below of=01,yshift=0.2cm] {\rkt{12}{sugar}};
+  \node (03) [below of=02,yshift=0.2cm] {\rkt{7}{penalty}};
+  \node (04) [below of=03,yshift=0.2cm] {\rkt{4}{ocm-struct}};
+  \node (05) [below of=04,yshift=0.2cm] {\rkt{3}{measure}};
+  \node (06) [below of=05,yshift=0.2cm] {\rkt{0}{exceptions}};
+  \node (07) [below of=06,yshift=0.2cm] {\rkt{6}{patterns-hashed}};
 
   \node (10) [left of=00] {\rkt{10}{quick-sample}};
   \node (11) [left of=01] {};
@@ -70,7 +70,7 @@
   \draw[->] (42) -- (25);
   \draw[->] (42) -- (02);
   %% main
-  \draw[->] (50) edge[bend left=15] (00);
+  \draw[->] (50) edge[bend left=35] (00);
   \draw[->] (50) -- (42);
   \draw[->] (50) -- (10);
   \draw[->] (50) -- (31);

--- a/paper/module-graphs/snake.tex
+++ b/paper/module-graphs/snake.tex
@@ -1,8 +1,8 @@
 \begin{tikzpicture}
 
   \node (00)               {};
-  \node (01) [below of=00,xshift=0.5cm] {\rkt{3}{data}};
-  \node (02) [below of=01,xshift=0.5cm] {};
+  \node (01) [below of=00,yshift=0.3cm] {\rkt{3}{data}};
+  \node (02) [below of=01,yshift=0.3cm] {};
 
   \node (10) [left of=00] {\rkt{1}{const}};
   \node (11) [left of=01] {};

--- a/paper/module-graphs/suffixtree.tex
+++ b/paper/module-graphs/suffixtree.tex
@@ -11,16 +11,16 @@
   %% label
   \draw[->] (1) -- (0);
   %% structs
-  \draw[->] (2) edge[bend right=75] (0);
+  \draw[->] (2) edge[bend right=35] (0);
   \draw[->] (2) -- (1);
   %% ukkonen
-  \draw[->] (3) edge[bend left=75] (0);
-  \draw[->] (3) edge[bend left=75] (1);
+  \draw[->] (3) edge[bend left=35] (0);
+  \draw[->] (3) edge[bend left=35] (1);
   \draw[->] (3) -- (2);
   %% lcs
-  \draw[->] (4) edge[bend right=75] (0);
-  \draw[->] (4) edge[bend right=75] (1);
-  \draw[->] (4) edge[bend right=75] (2);
+  \draw[->] (4) edge[bend right=35] (0);
+  \draw[->] (4) edge[bend right=35] (1);
+  \draw[->] (4) edge[bend right=35] (2);
   \draw[->] (4) -- (3);
   %% main
   \draw[->] (5) -- (4);

--- a/paper/module-graphs/tetris.tex
+++ b/paper/module-graphs/tetris.tex
@@ -1,8 +1,8 @@
 \begin{tikzpicture}
 
   \node (00)               {\rkt{3}{consts}};
-  \node (01) [below of=00,xshift=0.25cm] {};
-  \node (02) [below of=01,xshift=0.25cm] {\rkt{4}{data}};
+  \node (01) [below of=00,yshift=0.3cm] {};
+  \node (02) [below of=01,yshift=0.3cm] {\rkt{4}{data}};
 
   \node (10) [left of=00] {};
   \node (11) [left of=01] {};
@@ -34,21 +34,21 @@
   \draw[->] (20) -- (02);
   \draw[->] (20) -- (12);
   %% elim
-  \draw[->] (30) edge[bend left=50] (00);
+  \draw[->] (30) edge[bend left=35] (00);
   \draw[->] (30) -- (02);
   \draw[->] (30) -- (20);
   %% tetras
   \draw[->] (32) -- (00);
-  \draw[->] (32) edge[bend right=50] (02);
+  \draw[->] (32) edge[bend right=35] (02);
   \draw[->] (32) -- (12);
   \draw[->] (32) -- (20);
   %% aux
-  \draw[->] (42) edge[bend right=50] (02);
+  \draw[->] (42) edge[bend right=35] (02);
   \draw[->] (42) -- (32);
   %% world
-  \draw[->] (50) edge[bend left=50] (00);
+  \draw[->] (50) edge[bend left=35] (00);
   \draw[->] (50) -- (02);
-  \draw[->] (50) edge[bend left=50] (20);
+  \draw[->] (50) edge[bend left=35] (20);
   \draw[->] (50) -- (30);
   \draw[->] (50) -- (32);
   \draw[->] (50) -- (42);

--- a/paper/module-graphs/zordoz.tex
+++ b/paper/module-graphs/zordoz.tex
@@ -1,8 +1,8 @@
 \begin{tikzpicture}
 
   \node (00)               {\rkt{3}{zo-string}};
-  \node (01) [below of=00] {};
-  \node (02) [below of=01] {\rkt{4}{zo-transition}};
+  \node (01) [below of=00,yshift=0.3cm] {};
+  \node (02) [below of=01,yshift=0.3cm] {\rkt{4}{zo-transition}};
 
   \node (10) [left of=00] {};
   \node (11) [left of=01] {\rkt{1}{zo-find}};
@@ -19,8 +19,8 @@
   %% -- edges
   \draw[->] (11) -- (00);
   \draw[->] (11) -- (02);
-  \draw[->] (21) edge[bend left=30] (00);
-  \draw[->] (21) edge[bend right=30] (02);
+  \draw[->] (21) edge[bend left=35] (00);
+  \draw[->] (21) edge[bend right=35] (02);
   \draw[->] (21) -- (11);
   \draw[->] (31) -- (21);
 


### PR DESCRIPTION
- Made edges bend less, and uniformly
- Made some graphs skinnier (zordoz, quad, synth, snake)
- Removed the xshift offsets from all graphs except gregor
