### PR TITLE
[test-run] tests for run script pass+fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ install:
   - raco pkg install --deps search-auto $TRAVIS_BUILD_DIR/tools/diagnose
 
 script:
-  - raco test $TRAVIS_BUILD_DIR
+  - raco test $TRAVIS_BUILD_DIR/tools
+  - raco test $TRAVIS_BUILD_DIR/tools/run-test.rkt
   - raco setup --check-pkg-deps benchmark-util
   - raco setup --check-pkg-deps gtp-summarize
   - raco setup --check-pkg-deps gtp-diagnose

--- a/benchmarks/test-compile-error/README.md
+++ b/benchmarks/test-compile-error/README.md
@@ -1,0 +1,4 @@
+test-compile-error
+=====
+
+Example benchmark that fails to compile on some configurations.

--- a/benchmarks/test-compile-error/typed/aux.rkt
+++ b/benchmarks/test-compile-error/typed/aux.rkt
@@ -1,0 +1,5 @@
+#lang typed/racket/base
+
+(provide SLEEP-TIME)
+
+(define SLEEP-TIME 1)

--- a/benchmarks/test-compile-error/typed/main.rkt
+++ b/benchmarks/test-compile-error/typed/main.rkt
@@ -1,0 +1,11 @@
+#lang typed/racket/base
+
+(require benchmark-util)
+(require/typed/check "aux.rkt"
+  [SLEEP-TIME (<- COMPILE ERROR ->)])
+
+(define (main)
+  (add1 SLEEP-TIME)
+  (void))
+
+(time (main))

--- a/benchmarks/test-compile-error/untyped/aux.rkt
+++ b/benchmarks/test-compile-error/untyped/aux.rkt
@@ -1,0 +1,5 @@
+#lang racket/base
+
+(provide SLEEP-TIME)
+
+(define SLEEP-TIME 1)

--- a/benchmarks/test-compile-error/untyped/main.rkt
+++ b/benchmarks/test-compile-error/untyped/main.rkt
@@ -1,0 +1,10 @@
+#lang racket/base
+
+(require benchmark-util)
+(require "aux.rkt")
+
+(define (main)
+  (add1 SLEEP-TIME)
+  (void))
+
+(time (main))

--- a/benchmarks/test-runtime-error/README.md
+++ b/benchmarks/test-runtime-error/README.md
@@ -1,0 +1,4 @@
+test-runtime-error
+====
+
+Sample benchmark that fails at run-time for some configurations

--- a/benchmarks/test-runtime-error/typed/aux.rkt
+++ b/benchmarks/test-runtime-error/typed/aux.rkt
@@ -1,0 +1,4 @@
+#lang typed/racket/base
+
+(provide NUM-SLEEP)
+(define NUM-SLEEP 1)

--- a/benchmarks/test-runtime-error/typed/main.rkt
+++ b/benchmarks/test-runtime-error/typed/main.rkt
@@ -1,0 +1,9 @@
+#lang typed/racket/base
+
+(require benchmark-util)
+(require/typed/check "aux.rkt"
+  (NUM-SLEEP String))
+
+(define (main)
+  (add1 (assert NUM-SLEEP integer?))
+  (void))

--- a/benchmarks/test-runtime-error/untyped/aux.rkt
+++ b/benchmarks/test-runtime-error/untyped/aux.rkt
@@ -1,0 +1,4 @@
+#lang racket/base
+
+(provide NUM-SLEEP)
+(define NUM-SLEEP 1)

--- a/benchmarks/test-runtime-error/untyped/main.rkt
+++ b/benchmarks/test-runtime-error/untyped/main.rkt
@@ -1,0 +1,9 @@
+#lang racket/base
+
+(require benchmark-util)
+(require/typed/check "aux.rkt"
+  (NUM-SLEEP String))
+
+(define (main)
+  (add1 NUM-SLEEP)
+  (void))

--- a/benchmarks/test-success/README.md
+++ b/benchmarks/test-success/README.md
@@ -1,0 +1,4 @@
+test-success
+=====
+
+Example benchmark. Works great, quickly.

--- a/benchmarks/test-success/typed/aux.rkt
+++ b/benchmarks/test-success/typed/aux.rkt
@@ -1,0 +1,5 @@
+#lang typed/racket/base
+
+(provide SLEEP-TIME)
+
+(define SLEEP-TIME 1)

--- a/benchmarks/test-success/typed/main.rkt
+++ b/benchmarks/test-success/typed/main.rkt
@@ -1,0 +1,11 @@
+#lang typed/racket/base
+
+(require benchmark-util)
+(require/typed/check "aux.rkt"
+  [SLEEP-TIME Natural])
+
+(define (main)
+  (add1 SLEEP-TIME)
+  (void))
+
+(time (main))

--- a/benchmarks/test-success/untyped/aux.rkt
+++ b/benchmarks/test-success/untyped/aux.rkt
@@ -1,0 +1,5 @@
+#lang racket/base
+
+(provide SLEEP-TIME)
+
+(define SLEEP-TIME 1)

--- a/benchmarks/test-success/untyped/main.rkt
+++ b/benchmarks/test-success/untyped/main.rkt
@@ -1,0 +1,10 @@
+#lang racket/base
+
+(require benchmark-util)
+(require "aux.rkt")
+
+(define (main)
+  (add1 SLEEP-TIME)
+  (void))
+
+(time (main))

--- a/tools/run-test.rkt
+++ b/tools/run-test.rkt
@@ -32,7 +32,7 @@
           (lambda (p)
             (parameterize ([current-output-port (open-output-nowhere)]
                            [current-error-port p])
-              (run-benchmark (vector "-i" "1" project-dir)))))))
+              (run-benchmark (vector "-n" "-i" "1" project-dir)))))))
     (check-equal? (string=? "" str) should-pass?
       (format "Expected benchmark '~a' to ~a, but it ~a-ed instead."
         bm (pass/fail should-pass?) (pass/fail (not should-pass?))))

--- a/tools/run-test.rkt
+++ b/tools/run-test.rkt
@@ -1,0 +1,62 @@
+#lang racket/base
+
+;; Test example benchmarks
+;; - Correct benchmarks should run without error
+;; - Compile-error benchmarks should generate an error
+;; - Runtime-error benchmarks should generate an error
+
+(module+ test
+
+  (require
+    rackunit
+    (only-in racket/string string-split)
+    (only-in racket/port call-with-output-string open-output-nowhere)
+    gtp-summarize/modulegraph
+    "setup-benchmark.rkt"
+    "run.rkt")
+
+  (define (pass/fail should-pass?)
+    (if should-pass?
+      "PASS"
+      "FAIL"))
+
+  (define (check-benchmark bm #:max-output-lines [max-lines #f]
+                              #:output-rx* [rx* #f]
+                              #:should-fail? [should-fail? #f])
+    (define project-dir (path->string (infer-project-dir bm)))
+    (create-benchmark-dirs project-dir)
+    (define should-pass? (not should-fail?))
+    (define str
+      (parameterize ([error-print-context-length 0])
+        (call-with-output-string
+          (lambda (p)
+            (parameterize ([current-output-port (open-output-nowhere)]
+                           [current-error-port p])
+              (run-benchmark (vector "-i" "1" project-dir)))))))
+    (check-equal? (string=? "" str) should-pass?
+      (format "Expected benchmark '~a' to ~a, but it ~a-ed instead."
+        bm (pass/fail should-pass?) (pass/fail (not should-pass?))))
+    (when max-lines
+      (let ([L (length (string-split str "\n"))])
+        (check-true (<= L max-lines)
+          (format "Expected '~a' to generate at most ~a lines of output, got ~a lines."
+            bm max-lines L))))
+    (when rx*
+      (for/list ([rx (in-list (if (list? rx*) rx* (list rx*)))])
+        (check-regexp-match rx str)))
+    (void))
+
+  (check-benchmark "test-success"
+    #:max-output-lines 2)
+
+  (check-benchmark "test-compile-error"
+    #:should-fail? #t
+    #:output-rx* '(#rx"Type Checker" #rx"run:compile" #rx"configuration01")
+    #:max-output-lines 30)
+
+  (check-benchmark "test-runtime-error"
+    #:should-fail? #t
+    #:output-rx* '(#rx"run:runtime" #rx"configuration01")
+    #:max-output-lines 20)
+
+)

--- a/tools/setup-benchmark.rkt
+++ b/tools/setup-benchmark.rkt
@@ -20,7 +20,7 @@
 (define UNTYPED "no")
 (define COMMENT (string-append ";; " (make-string 77 #\-)))
 
-(define (create-benchmark-dirs 
+(define (create-benchmark-dirs
          pwd
          #:base [base (build-path pwd "base")]
          #:both [both (build-path pwd "both")]

--- a/tools/summarize/info.rkt
+++ b/tools/summarize/info.rkt
@@ -5,6 +5,7 @@
                "typed-racket-more"
                "benchmark-util" ;; local package
                "rackunit-lib"
+               "rackunit-abbrevs"
                "draw-lib" ;; For the mini-quadMB test ... oh well
                "glob"
                "trivial"

--- a/tools/summarize/test/mini-quadMB/base/csp/helper.rkt
+++ b/tools/summarize/test/mini-quadMB/base/csp/helper.rkt
@@ -1,7 +1,6 @@
 #lang racket/base
 (require racket/class racket/list (for-syntax racket/base racket/syntax))
 (provide (all-defined-out))
-(require rackunit)
 
 (define-syntax-rule (forever expr ...)
   (for ([i (in-naturals)])
@@ -21,10 +20,6 @@
                   (send/apply this proc-name args))])
               proc-name))
 
-(define-simple-check (check-hash-items h1 h2)
-  (for/and ([(k1 v1) (in-hash h1)])
-    (equal? (hash-ref h2 k1) v1)))
-
 (define (list-comparator xs ys)
   ;; For use in sort. Compares two lists element by element.
   (cond
@@ -39,13 +34,6 @@
               [(and (string? x) (string? y)) (string<? x y)]
               [else (error 'list-comparator (format "Can’t compare ~v and ~v" x y))]))]))
 
-(module+ test 
-  (check-false (list-comparator null null))
-  (check-false (list-comparator (range 2) (range 2)))
-  (check-true (list-comparator (range 2) (range 4)))
-  (check-false (list-comparator (range 4) (range 2)))
-  (check-true (list-comparator '(1 1 "a") '(1 1 "b")))
-  (check-true (list-comparator '(1 1 a) '(1 1 b))))
 
 (define-syntax-rule (car-pop! xs)
   (let ([i (car xs)])
@@ -57,24 +45,12 @@
       (set! xs (drop-right xs 1))
       i))
 
-(module+ test
-  (let ([xs '(1 2 3)])
-    (check-equal? (py-pop! xs) 3)
-    (check-equal? xs '(1 2))))
 
 (define-syntax-rule (py-append! xs x)
   (set! xs `(,@xs ,x)))
 
 (define-syntax-rule (py-extend! xs x)
   (set! xs `(,@xs ,@x)))
-
-(module+ test
-  (let ([xs '(1 2 3)])
-    (py-append! xs (range 2))
-    (check-equal? xs '(1 2 3 (0 1))))
-  (let ([xs '(1 2 3)])
-    (py-extend! xs (range 2))
-    (check-equal? xs '(1 2 3 0 1))))
 
 
 (define (word-value . xs)


### PR DESCRIPTION
Adds a unit test for `tools/run.rkt`. We run 3 dummy benchmarks & check that:
- The successful one runs without producing an error message
- One with a compile error generates a typechecker error
- One with a runtime error generates a runtime error

This was prompted because a runtime error happened in one of the MANY configurations of `quadBG`, and I'm still not sure which one.